### PR TITLE
don't set refreshing while computing layout

### DIFF
--- a/library/src/main/java/com/github/yasevich/endlessrecyclerview/EndlessRecyclerView.java
+++ b/library/src/main/java/com/github/yasevich/endlessrecyclerview/EndlessRecyclerView.java
@@ -164,7 +164,7 @@ public final class EndlessRecyclerView extends RecyclerView {
      * @param refreshing {@code true} if list is currently refreshing, {@code false} otherwise
      */
     public void setRefreshing(boolean refreshing) {
-        if (this.refreshing == refreshing) {
+        if (this.refreshing == refreshing || isComputingLayout()) {
             return;
         }
         this.refreshing = refreshing;


### PR DESCRIPTION
I had a bug in my app when adapter have few items and endlessRecyclerView tries to set refreshing, it was throwing this exception `Fatal Exception: java.lang.IllegalStateException: Cannot call this method while RecyclerView is computing a layout or scrolling`, so I fixed it just by adding 2 condition to set refreshing (return if `#isComputingLayout()` is true).
